### PR TITLE
Fix: conman - freeipmi as explicit dependency in specfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0 - Next-release
+
+  - Added missing freeipmi dependency to conman spec (#1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 1.0.0 - Next-release
 
-  - Added missing freeipmi dependency to conman spec (#1)
+  - Added missing freeipmi dependency to conman spec (#14)

--- a/packages/conman/conman.spec
+++ b/packages/conman/conman.spec
@@ -11,7 +11,7 @@ Source0:	https://github.com/dun/conman/releases/download/%{name}-%{version}/%{na
 BuildRequires:	freeipmi-devel >= 1.0.4
 #BuildRequires:	tcp_wrappers-devel
 BuildRequires:	systemd
-Requires:	expect
+Requires:	expect, freeipmi
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd


### PR DESCRIPTION
Usually you need to configure conman with --with-freeipmi first, but it`s being taken by default.

The conmand  binary itself shows links to the freeipmi libraries:
libipmiconsole.so.2 => /lib64/libipmiconsole.so.2
libfreeipmi.so.17 => /lib64/libfreeipmi.so.17