### PR TITLE
Updated ipxe-x86_64-bluebanquise.spec to work with OpenSuSE 15.3

### DIFF
--- a/packages/ipxe-bluebanquise/ipxe-x86_64-bluebanquise.spec
+++ b/packages/ipxe-bluebanquise/ipxe-x86_64-bluebanquise.spec
@@ -1,6 +1,14 @@
 # Leap 15.1:
-%if 0%{?is_opensuse} && 0%{?sle_version} == 150100
+%if 0%{?sle_version} == 150100
 %define dist .lp151
+%endif
+# Leap 15.2:
+%if 0%{?sle_version} == 150200
+%define dist .lp152
+%endif
+# Leap 15.3:
+%if 0%{?sle_version} == 150300
+%define dist .lp153
 %endif
 
 %if 0%{?is_opensuse} 


### PR DESCRIPTION
This pull request fixes issue #16 following advice from https://en.opensuse.org/openSUSE:Packaging_for_Leap which states that the macro `is_opensuse` is undefined and also states:

> Important Update as of 2021: is_opensuse ideally notbe used only. To distinguish in between openSUSE Tumbleweed and SUSE Linux Enterprise check the presence of sle_version. openSUSE Leap 15.3+ should have the identical functionality as SUSE Linux Enterprise.