### PR TITLE
packages: use new ipxe path

### DIFF
--- a/packages/bluebanquise-ipxe/bluebanquise-ipxe-arm64.spec
+++ b/packages/bluebanquise-ipxe/bluebanquise-ipxe-arm64.spec
@@ -73,9 +73,9 @@ Description:
 working_directory=XXX
 
 # arm64
-mkdir -p $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/arm64
-cp $working_directory/build/ipxe/bin/arm64/grub2_efi_autofind.img $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/arm64/grub2_efi_autofind.img
-cp $working_directory/build/ipxe/bin/arm64/grub2_shell.img $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/arm64/grub2_shell.img
+mkdir -p $RPM_BUILD_ROOT/%{http_path}/pxe/bin/arm64
+cp $working_directory/build/ipxe/bin/arm64/grub2_efi_autofind.img $RPM_BUILD_ROOT/%{http_path}/pxe/bin/arm64/grub2_efi_autofind.img
+cp $working_directory/build/ipxe/bin/arm64/grub2_shell.img $RPM_BUILD_ROOT/%{http_path}/pxe/bin/arm64/grub2_shell.img
 
 mkdir -p $RPM_BUILD_ROOT/%{tftp_path}/arm64
 cp $working_directory/build/ipxe/bin/arm64/standard_ipxe.efi $RPM_BUILD_ROOT/%{tftp_path}/arm64/standard_ipxe.efi
@@ -87,8 +87,8 @@ cp $working_directory/build/ipxe/bin/arm64/dhcpretry_snp_ipxe.efi $RPM_BUILD_ROO
 
 %files
 %defattr(-,root,root,-)
-%{http_path}/preboot_execution_environment/bin/arm64/grub2_efi_autofind.img
-%{http_path}/preboot_execution_environment/bin/arm64/grub2_shell.img
+%{http_path}/pxe/bin/arm64/grub2_efi_autofind.img
+%{http_path}/pxe/bin/arm64/grub2_shell.img
 %{tftp_path}/arm64/standard_ipxe.efi
 %{tftp_path}/arm64/standard_snponly_ipxe.efi
 %{tftp_path}/arm64/standard_snp_ipxe.efi

--- a/packages/bluebanquise-ipxe/bluebanquise-ipxe-x86_64.spec
+++ b/packages/bluebanquise-ipxe/bluebanquise-ipxe-x86_64.spec
@@ -73,16 +73,16 @@ Description:
 working_directory=XXX
 
 # x86_64
-mkdir -p $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64
-cp $working_directory/build/ipxe/bin/x86_64/grub2_efi_autofind.img $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/grub2_efi_autofind.img
-cp $working_directory/build/ipxe/bin/x86_64/grub2_shell.img $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/grub2_shell.img
-cp $working_directory/build/ipxe/bin/x86_64/standard_efi.iso $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/standard_efi.iso
-#cp $working_directory/build/ipxe/bin/x86_64/standard_pcbios.iso $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/standard_pcbios.iso
-#cp $working_directory/build/ipxe/bin/x86_64/standard_pcbios.usb $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/standard_pcbios.usb
-cp $working_directory/build/ipxe/bin/x86_64/dhcpretry_efi.iso $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/dhcpretry_efi.iso
-cp $working_directory/build/ipxe/bin/x86_64/noshell_efi.iso $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/noshell_efi.iso
-#cp $working_directory/build/ipxe/bin/x86_64/dhcpretry_pcbios.iso $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/dhcpretry_pcbios.iso
-#cp $working_directory/build/ipxe/bin/x86_64/dhcpretry_pcbios.usb $RPM_BUILD_ROOT/%{http_path}/preboot_execution_environment/bin/x86_64/dhcpretry_pcbios.usb
+mkdir -p $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64
+cp $working_directory/build/ipxe/bin/x86_64/grub2_efi_autofind.img $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/grub2_efi_autofind.img
+cp $working_directory/build/ipxe/bin/x86_64/grub2_shell.img $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/grub2_shell.img
+cp $working_directory/build/ipxe/bin/x86_64/standard_efi.iso $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/standard_efi.iso
+#cp $working_directory/build/ipxe/bin/x86_64/standard_pcbios.iso $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/standard_pcbios.iso
+#cp $working_directory/build/ipxe/bin/x86_64/standard_pcbios.usb $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/standard_pcbios.usb
+cp $working_directory/build/ipxe/bin/x86_64/dhcpretry_efi.iso $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/dhcpretry_efi.iso
+cp $working_directory/build/ipxe/bin/x86_64/noshell_efi.iso $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/noshell_efi.iso
+#cp $working_directory/build/ipxe/bin/x86_64/dhcpretry_pcbios.iso $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/dhcpretry_pcbios.iso
+#cp $working_directory/build/ipxe/bin/x86_64/dhcpretry_pcbios.usb $RPM_BUILD_ROOT/%{http_path}/pxe/bin/x86_64/dhcpretry_pcbios.usb
 
 
 mkdir -p $RPM_BUILD_ROOT/%{tftp_path}/x86_64
@@ -101,15 +101,15 @@ cp $working_directory/build/ipxe/bin/x86_64/noshell_snp_ipxe.efi $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
-%{http_path}/preboot_execution_environment/bin/x86_64/grub2_efi_autofind.img
-%{http_path}/preboot_execution_environment/bin/x86_64/grub2_shell.img
-%{http_path}/preboot_execution_environment/bin/x86_64/standard_efi.iso
-#%{http_path}/preboot_execution_environment/bin/x86_64/standard_pcbios.iso
-#%{http_path}/preboot_execution_environment/bin/x86_64/standard_pcbios.usb
-%{http_path}/preboot_execution_environment/bin/x86_64/dhcpretry_efi.iso
-%{http_path}/preboot_execution_environment/bin/x86_64/noshell_efi.iso
-#%{http_path}/preboot_execution_environment/bin/x86_64/dhcpretry_pcbios.iso
-#%{http_path}/preboot_execution_environment/bin/x86_64/dhcpretry_pcbios.usb
+%{http_path}/pxe/bin/x86_64/grub2_efi_autofind.img
+%{http_path}/pxe/bin/x86_64/grub2_shell.img
+%{http_path}/pxe/bin/x86_64/standard_efi.iso
+#%{http_path}/pxe/bin/x86_64/standard_pcbios.iso
+#%{http_path}/pxe/bin/x86_64/standard_pcbios.usb
+%{http_path}/pxe/bin/x86_64/dhcpretry_efi.iso
+%{http_path}/pxe/bin/x86_64/noshell_efi.iso
+#%{http_path}/pxe/bin/x86_64/dhcpretry_pcbios.iso
+#%{http_path}/pxe/bin/x86_64/dhcpretry_pcbios.usb
 %{tftp_path}/x86_64/standard_ipxe.efi
 %{tftp_path}/x86_64/standard_undionly.kpxe
 %{tftp_path}/x86_64/standard_snponly_ipxe.efi

--- a/packages/bluebanquise-ipxe/bluebanquise_ipxe.spec
+++ b/packages/bluebanquise-ipxe/bluebanquise_ipxe.spec
@@ -26,8 +26,8 @@ mkdir ipxe
 git clone https://github.com/ipxe/ipxe.git ipxe/.
 
 grub2-mkstandalone -O x86_64-efi -o grub2-efi-autofind.img "boot/grub/grub.cfg=grub2-efi-autofind.cfg"
-mkdir -p $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/
-cp grub2-efi-autofind.img $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/
+mkdir -p $RPM_BUILD_ROOT/var/www/html/pxe/bin/
+cp grub2-efi-autofind.img $RPM_BUILD_ROOT/var/www/html/pxe/bin/
 
 cp bluebanquise_standard.ipxe ipxe/src/bluebanquise_standard.ipxe
 
@@ -64,7 +64,7 @@ cp ipxe-efi.iso $RPM_BUILD_ROOT/var/lib/tftpboot/ipxe-efi.iso
 
 %files
 %defattr(-,root,root,-)
-/var/www/html/preboot_execution_environment/bin/grub2-efi-autofind.img
+/var/www/html/pxe/bin/grub2-efi-autofind.img
 /var/lib/tftpboot/bluebanquise_standard_ipxe.efi
 /var/lib/tftpboot/bluebanquise_standard_undionly.kpxe
 /var/lib/tftpboot/ipxe.iso

--- a/packages/bluebanquise-ipxe/ipxe-bluebanquise.spec
+++ b/packages/bluebanquise-ipxe/ipxe-bluebanquise.spec
@@ -29,12 +29,12 @@ Description:
 %install
 
 # x86_64
-mkdir -p $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/x86_64
-cp /root/build/bin/http/x86_64/grub2_efi_autofind.img $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/x86_64/grub2_efi_autofind.img
-cp /root/build/bin/http/x86_64/grub2_shell.img $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/x86_64/grub2_shell.img
-cp /root/build/bin/http/x86_64/ipxe_efi.iso $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/x86_64/ipxe_efi.iso
-cp /root/build/bin/http/x86_64/ipxe_legacy.iso $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/x86_64/ipxe_legacy.iso
-cp /root/build/bin/http/x86_64/ipxe.usb $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/bin/x86_64/ipxe.usb
+mkdir -p $RPM_BUILD_ROOT/var/www/html/pxe/bin/x86_64
+cp /root/build/bin/http/x86_64/grub2_efi_autofind.img $RPM_BUILD_ROOT/var/www/html/pxe/bin/x86_64/grub2_efi_autofind.img
+cp /root/build/bin/http/x86_64/grub2_shell.img $RPM_BUILD_ROOT/var/www/html/pxe/bin/x86_64/grub2_shell.img
+cp /root/build/bin/http/x86_64/ipxe_efi.iso $RPM_BUILD_ROOT/var/www/html/pxe/bin/x86_64/ipxe_efi.iso
+cp /root/build/bin/http/x86_64/ipxe_legacy.iso $RPM_BUILD_ROOT/var/www/html/pxe/bin/x86_64/ipxe_legacy.iso
+cp /root/build/bin/http/x86_64/ipxe.usb $RPM_BUILD_ROOT/var/www/html/pxe/bin/x86_64/ipxe.usb
 
 mkdir -p $RPM_BUILD_ROOT/var/lib/tftpboot/x86_64
 cp /root/build/bin/tftp/x86_64/standard_ipxe.efi $RPM_BUILD_ROOT/var/lib/tftpboot/x86_64/standard_ipxe.efi
@@ -51,11 +51,11 @@ cp /root/build/bin/tftp/arm64/standard_snp_ipxe.efi $RPM_BUILD_ROOT/var/lib/tftp
 
 %files
 %defattr(-,root,root,-)
-/var/www/html/preboot_execution_environment/bin/x86_64/grub2_efi_autofind.img
-/var/www/html/preboot_execution_environment/bin/x86_64/grub2_shell.img
-/var/www/html/preboot_execution_environment/bin/x86_64/ipxe_efi.iso
-/var/www/html/preboot_execution_environment/bin/x86_64/ipxe_legacy.iso
-/var/www/html/preboot_execution_environment/bin/x86_64/ipxe.usb
+/var/www/html/pxe/bin/x86_64/grub2_efi_autofind.img
+/var/www/html/pxe/bin/x86_64/grub2_shell.img
+/var/www/html/pxe/bin/x86_64/ipxe_efi.iso
+/var/www/html/pxe/bin/x86_64/ipxe_legacy.iso
+/var/www/html/pxe/bin/x86_64/ipxe.usb
 /var/lib/tftpboot/x86_64/standard_ipxe.efi
 /var/lib/tftpboot/x86_64/standard_undionly.kpxe
 /var/lib/tftpboot/x86_64/standard_snponly_ipxe.efi

--- a/packages/mll/mll.spec
+++ b/packages/mll/mll.spec
@@ -35,18 +35,18 @@ MLL build for BlueBanquise PXE
 %setup -q
 
 %post
-restorecon -Rv /var/www/html/preboot_execution_environment/MLL
+restorecon -Rv /var/www/html/pxe/MLL
 
 %build
 
 %install
 # Populate binaries
-mkdir -p $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/MLL/%{_architecture}/
-cp kernel.xz rootfs.xz $RPM_BUILD_ROOT/var/www/html/preboot_execution_environment/MLL/%{_architecture}/
+mkdir -p $RPM_BUILD_ROOT/var/www/html/pxe/MLL/%{_architecture}/
+cp kernel.xz rootfs.xz $RPM_BUILD_ROOT/var/www/html/pxe/MLL/%{_architecture}/
 
 %files
 %defattr(-,root,root,-)
-/var/www/html/preboot_execution_environment/MLL/%{_architecture}/*
+/var/www/html/pxe/MLL/%{_architecture}/*
 
 %changelog
 


### PR DESCRIPTION
Looks like some specs still had old preboot_execution_environment path.
 